### PR TITLE
Fix #224: Dll load error when importing on Windows 10...

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -82,7 +82,7 @@ if sys.platform == 'win32':
     ext_modules.append(Extension('bluetooth._msbt',
                           include_dirs=["%s\\Include" % PSDK_PATH, ".\\port3"],
                           library_dirs=[lib_path],
-                          libraries=["WS2_32", "Irprops"],
+                          libraries=["WS2_32", "Bthprops"],
                           sources=['msbt\\_msbt.c']))
 
     # widcomm


### PR DESCRIPTION
Changed Irprops dependency for _msbt to Bthprops.
Bthprops is the supported and recommended bluetooth library on Windows.
Irprops is only present for driver backward compatibility.
Irprops may not be available on newer versions of Windows.